### PR TITLE
chorse: add ignored warning for fasttext

### DIFF
--- a/data_filtering/filtering.py
+++ b/data_filtering/filtering.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 
 import fasttext
+fasttext.FastText.eprint = lambda x: None
 
 import sentencepiece
 import kenlm


### PR DESCRIPTION
When running the fasttext appear the warning so much, but not really significant, I put the ignored warning to have better experimence in preprocess data.